### PR TITLE
Implement faster decompositions

### DIFF
--- a/Sake/DecomposeMixer.cs
+++ b/Sake/DecomposeMixer.cs
@@ -38,7 +38,7 @@ public static class Decomposer
 					.TakeUntil(x => x.Sum == target));
 		}
 
-		return denoms.SelectMany((_, i) => Combinations(i, 0ul, 0, maxLength - 1)).Take(50).ToList();
+		return denoms.SelectMany((_, i) => Combinations(i, 0ul, 0, maxLength - 1)).Take(500).ToList();
 	}
 
 	private static int Search(long value, long[] denoms, int offset)

--- a/Sake/DecomposeMixer.cs
+++ b/Sake/DecomposeMixer.cs
@@ -1,5 +1,8 @@
 ﻿namespace Sake;
 
+/// <summary>
+/// https://github.com/lontivero/DecompositionsPlayground/blob/master/Notebook.ipynb
+/// </summary>
 public static class Decomposer
 {
 	public static long[] StdDenoms;

--- a/Sake/DecomposeMixer.cs
+++ b/Sake/DecomposeMixer.cs
@@ -1,4 +1,4 @@
-﻿namespace Sake;
+namespace Sake;
 
 /// <summary>
 /// https://github.com/lontivero/DecompositionsPlayground/blob/master/Notebook.ipynb
@@ -9,9 +9,22 @@ public static class Decomposer
 
 	public static IEnumerable<(long Sum, int Count, ulong Decomposition)> Decompose(long target, long tolerance, int maxCount)
 	{
+		if (maxCount is <= 1 or > 8)
+		{
+			throw new ArgumentOutOfRangeException(nameof(maxCount), "The maximum decomposition lenght cannot be greater than 8 or smaller than 1.");
+		}
+		if (target <= 0)
+		{
+			throw new ArgumentException("Only possitive numbers can be decomposed.", nameof(target));
+		}
+
 		var denoms = StdDenoms.SkipWhile(x => x > target).ToArray();
 
-		return denoms.SelectMany((_, i) => InternalCombinations(target, tolerance: tolerance / 10, maxCount, denoms)).Take(10000).ToList();
+		if (denoms.Length > 255)
+		{
+			throw new ArgumentException("Too many denominations. Maximum number is 256.", nameof(target));
+		}
+		return denoms.SelectMany((_, i) => InternalCombinations(target, tolerance: tolerance, maxCount, denoms)).Take(10000).ToList();
 	}
 
 	private static IEnumerable<(long Sum, int Count, ulong Decomposition)> InternalCombinations(long target, long tolerance, int maxLength, long[] denoms)

--- a/Sake/DecomposeMixer.cs
+++ b/Sake/DecomposeMixer.cs
@@ -1,4 +1,4 @@
-namespace Sake;
+﻿namespace Sake;
 
 /// <summary>
 /// https://github.com/lontivero/DecompositionsPlayground/blob/master/Notebook.ipynb
@@ -51,7 +51,7 @@ public static class Decomposer
 					.TakeUntil(x => x.Sum == target));
 		}
 
-		return denoms.SelectMany((_, i) => Combinations(i, 0ul, 0, maxLength - 1)).Take(500).ToList();
+		return denoms.SelectMany((_, i) => Combinations(i, 0ul, 0, maxLength - 1)).Take(5000).ToList();
 	}
 
 	private static int Search(long value, long[] denoms, int offset)

--- a/Sake/DecomposeMixer.cs
+++ b/Sake/DecomposeMixer.cs
@@ -1,0 +1,80 @@
+﻿namespace Sake;
+
+public static class Decomposer
+{
+	public static long[] StdDenoms;
+
+	public static IEnumerable<(long Sum, int Count, ulong Decomposition)> Decompose(long target, long tolerance, int maxCount)
+	{
+		var denoms = StdDenoms.SkipWhile(x => x > target).ToArray();
+
+		return denoms.SelectMany((_, i) => InternalCombinations(target, tolerance: tolerance / 10, maxCount, denoms)).Take(10000).ToList();
+	}
+
+	private static IEnumerable<(long Sum, int Count, ulong Decomposition)> InternalCombinations(long target, long tolerance, int maxLength, long[] denoms)
+	{
+		IEnumerable<(long Sum, int Count, ulong Decomposition)> Combinations(
+			int currentDenominationIdx,
+			ulong accumulator,
+			long sum,
+			int k)
+		{
+			accumulator = (accumulator << 8) | ((ulong)currentDenominationIdx & 0xff);
+			var currentDenomination = denoms[currentDenominationIdx];
+			sum += currentDenomination;
+			var remaining = target - sum;
+			if (k == 0 || remaining < tolerance)
+				return new[] { (sum, maxLength - k, accumulator) };
+
+			currentDenominationIdx = Search(remaining, denoms, currentDenominationIdx);
+
+			return Enumerable.Range(0, denoms.Length - currentDenominationIdx)
+				.TakeWhile(i => k * denoms[currentDenominationIdx + i] >= remaining - tolerance)
+				.SelectMany((_, i) =>
+					Combinations(currentDenominationIdx + i, accumulator, sum, k - 1)
+					.TakeUntil(x => x.Sum == target));
+		}
+
+		return denoms.SelectMany((_, i) => Combinations(i, 0ul, 0, maxLength - 1)).Take(50).ToList();
+	}
+
+	private static int Search(long value, long[] denoms, int offset)
+	{
+		var startingIndex = Array.BinarySearch(denoms, offset, denoms.Length - offset, value, ReverseComparer.Default);
+		return startingIndex < 0 ? ~startingIndex : startingIndex;
+	}
+
+	public static IEnumerable<long> ToRealValuesArray(ulong decomposition, int count, long[] denoms)
+	{
+		var list = new long[count];
+		for (var i = 0; i < count; i++)
+		{
+			var index = (decomposition >> (i * 8)) & 0xff;
+			list[count - i - 1] = denoms[index];
+		}
+		return list;
+	}
+}
+
+public static class LinqEx
+{
+	public static IEnumerable<T> TakeUntil<T>(this IEnumerable<T> list, Func<T, bool> predicate)
+	{
+		foreach (T el in list)
+		{
+			yield return el;
+			if (predicate(el))
+				yield break;
+		}
+	}
+}
+
+public class ReverseComparer : IComparer<long>
+{
+	public static readonly ReverseComparer Default = new();
+	public int Compare(long x, long y)
+	{
+		// Compare y and x in reverse order.
+		return y.CompareTo(x);
+	}
+}

--- a/Sake/Mixer.cs
+++ b/Sake/Mixer.cs
@@ -181,11 +181,19 @@ namespace Sake
         public IEnumerable<ulong> Decompose(IEnumerable<ulong> myInputsParam, IEnumerable<ulong> othersInputsParam)
         {
             // Filter out and order denominations those have occured in the frequency table at least twice.
-            var denoms = DenominationFrequencies
+            // Filter out denominations very close to each other.
+            List<ulong> denoms = new();
+            foreach(var denom in DenominationFrequencies
                 .Where(x => x.Value > 1)
                 .OrderByDescending(x => x.Key)
                 .Select(x => x.Key)
-                .ToArray();
+                .ToArray())
+            {
+                if (!denoms.Any() || denom <= (denoms.Last() / 1.1))
+                {
+                    denoms.Add(denom);
+                }
+            }
 
             var myInputs = myInputsParam.Select(x => x - InputFee).ToArray();
             var myInputSum = myInputs.Sum();

--- a/Sake/Mixer.cs
+++ b/Sake/Mixer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -269,13 +269,6 @@ namespace Sake
                 foreach (var item in currentSet.OrderBy(x => x))
                 {
                     hash.Add(item);
-                }
-
-                // Add change output if necessary.
-                var diff = (ulong)sum - currentSet.Sum();
-                if (diff > MinAllowedOutputAmountPlusFee)
-                {
-                    currentSet.Add(diff);
                 }
                 setCandidates.TryAdd(hash.ToHashCode(), (currentSet, myInputSum - (ulong)currentSet.Sum() + (ulong)count * OutputFee)); // The cost is the remaining + output cost.
             }

--- a/Sake/Mixer.cs
+++ b/Sake/Mixer.cs
@@ -257,7 +257,7 @@ namespace Sake
 
             // Create many decompositions for optimization.
             Decomposer.StdDenoms = denoms.Where(x => x <= myInputSum).Select(x => (long)x).ToArray();
-            foreach (var (sum, count, decomp) in Decomposer.Decompose((long)myInputSum, (long)MinAllowedOutputAmountPlusFee, Math.Max(3, naiveSet.Count)))
+            foreach (var (sum, count, decomp) in Decomposer.Decompose((long)myInputSum, (long)loss, Math.Max(3, naiveSet.Count)))
             {
                 var currentSet = Decomposer.ToRealValuesArray(
                     decomp,

--- a/Sake/Mixer.cs
+++ b/Sake/Mixer.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -258,7 +258,7 @@ namespace Sake
 
             // Create many decompositions for optimization.
             Decomposer.StdDenoms = denoms.Where(x => x <= myInputSum).Select(x => (long)x).ToArray();
-            foreach (var (sum, count, decomp) in Decomposer.Decompose((long)myInputSum, (long)loss, Math.Min(10, Math.Max(5, naiveSet.Count))))
+            foreach (var (sum, count, decomp) in Decomposer.Decompose((long)myInputSum, (long)loss, Math.Min(8, Math.Max(5, naiveSet.Count))))
             {
                 var currentSet = Decomposer.ToRealValuesArray(
                     decomp,

--- a/Sake/Mixer.cs
+++ b/Sake/Mixer.cs
@@ -258,7 +258,7 @@ namespace Sake
 
             // Create many decompositions for optimization.
             Decomposer.StdDenoms = denoms.Where(x => x <= myInputSum).Select(x => (long)x).ToArray();
-            foreach (var (sum, count, decomp) in Decomposer.Decompose((long)myInputSum, (long)loss, Math.Max(5, naiveSet.Count)))
+            foreach (var (sum, count, decomp) in Decomposer.Decompose((long)myInputSum, (long)loss, Math.Min(10, Math.Max(5, naiveSet.Count))))
             {
                 var currentSet = Decomposer.ToRealValuesArray(
                     decomp,
@@ -289,7 +289,12 @@ namespace Sake
                 if (random.NextDouble() < 0.5)
                 {
                     finalCandidate = candidate.Decomp;
-                    Leftovers.Add((int)(myInputSum - candidate.Decomp.Sum()));
+                    int leftover = (int)(myInputSum - candidate.Decomp.Sum());
+                    if (leftover > 10000)
+                    {
+                        Console.WriteLine($"END OF THE WORLD. LEFTOVER TOO BIG: {leftover}");
+                    }
+                    Leftovers.Add(leftover);
                     break;
                 }
             }

--- a/Sake/Mixer.cs
+++ b/Sake/Mixer.cs
@@ -257,7 +257,7 @@ namespace Sake
 
             // Create many decompositions for optimization.
             Decomposer.StdDenoms = denoms.Where(x => x <= myInputSum).Select(x => (long)x).ToArray();
-            foreach (var (sum, count, decomp) in Decomposer.Decompose((long)myInputSum, (long)loss, Math.Max(3, naiveSet.Count)))
+            foreach (var (sum, count, decomp) in Decomposer.Decompose((long)myInputSum, (long)loss, Math.Max(5, naiveSet.Count)))
             {
                 var currentSet = Decomposer.ToRealValuesArray(
                     decomp,

--- a/Sake/Mixer.cs
+++ b/Sake/Mixer.cs
@@ -32,6 +32,7 @@ namespace Sake
         public uint FeeRate { get; }
         public uint InputSize { get; }
         public uint OutputSize { get; }
+        public List<int> Leftovers { get; } = new();
         public IOrderedEnumerable<ulong> DenominationsPlusFees { get; }
 
         /// <summary>
@@ -288,12 +289,14 @@ namespace Sake
                 if (random.NextDouble() < 0.5)
                 {
                     finalCandidate = candidate.Decomp;
+                    Leftovers.Add((int)(myInputSum - candidate.Decomp.Sum()));
                     break;
                 }
             }
 
             return finalCandidate.Select(x => x - OutputFee);
         }
+
 
         private void SetDenominationFrequencies(IEnumerable<ulong> inputs)
         {

--- a/Sake/Mixer.cs
+++ b/Sake/Mixer.cs
@@ -259,17 +259,17 @@ namespace Sake
             Decomposer.StdDenoms = denoms.Where(x => x <= myInputSum).Select(x => (long)x).ToArray();
             foreach (var (sum, count, decomp) in Decomposer.Decompose((long)myInputSum, (long)MinAllowedOutputAmountPlusFee, Math.Max(3, naiveSet.Count)))
             {
-                var set = Decomposer.ToRealValuesArray(
+                var currentSet = Decomposer.ToRealValuesArray(
                     decomp,
                     count,
                     Decomposer.StdDenoms).Cast<ulong>().ToArray();
 
                 hash = new();
-                foreach (var item in naiveSet.OrderBy(x => x))
+                foreach (var item in currentSet.OrderBy(x => x))
                 {
                     hash.Add(item);
                 }
-                setCandidates.TryAdd(hash.ToHashCode(), (set, myInputSum - (ulong)sum + (ulong)count * OutputFee)); // The cost is the remaining + output cost.
+                setCandidates.TryAdd(hash.ToHashCode(), (currentSet, myInputSum - (ulong)sum + (ulong)count * OutputFee)); // The cost is the remaining + output cost.
             }
 
             var denomHashSet = denoms.ToHashSet();

--- a/Sake/Mixer.cs
+++ b/Sake/Mixer.cs
@@ -258,7 +258,7 @@ namespace Sake
 
             // Create many decompositions for optimization.
             Decomposer.StdDenoms = denoms.Where(x => x <= myInputSum).Select(x => (long)x).ToArray();
-            foreach (var (sum, count, decomp) in Decomposer.Decompose((long)myInputSum, (long)loss, Math.Min(8, Math.Max(5, naiveSet.Count))))
+            foreach (var (sum, count, decomp) in Decomposer.Decompose((long)myInputSum, (long)Math.Max(loss, 0.5 * MinAllowedOutputAmountPlusFee) , Math.Min(8, Math.Max(5, naiveSet.Count))))
             {
                 var currentSet = Decomposer.ToRealValuesArray(
                     decomp,

--- a/Sake/Program.cs
+++ b/Sake/Program.cs
@@ -82,3 +82,7 @@ Console.WriteLine($"Average anonset:\t{Analyzer.AverageAnonsetGain(inputGroups, 
 Console.WriteLine($"Average input anonset:\t{Analyzer.AverageAnonsetGain(inputGroups):0.##}");
 Console.WriteLine($"Average output anonset:\t{Analyzer.AverageAnonsetGain(outputGroups):0.##}");
 Console.WriteLine($"Blockspace efficiency:\t{Analyzer.BlockspaceEfficiency(inputGroups, outputGroups, size):0.##}");
+Console.WriteLine($"Total leftover:\t\t{mixer.Leftovers.Sum():0}");
+Console.WriteLine($"Average leftover:\t{mixer.Leftovers.Average():0}");
+Console.WriteLine($"Median leftover:\t{mixer.Leftovers.Median():0}");
+Console.WriteLine($"Largest leftover:\t{mixer.Leftovers.Max():0}");

--- a/Sake/Program.cs
+++ b/Sake/Program.cs
@@ -2,87 +2,92 @@
 using System;
 using System.Linq;
 
-var inputCount = 100;
-var userCount = 30;
-var remixRatio = 0.3;
-
-var preRandomAmounts = Sample.Amounts.RandomElements(inputCount).Select(x => x.ToSats());
-var preGroups = preRandomAmounts.RandomGroups(userCount);
-
-var preMixer = new Mixer();
-var preMix = preMixer.CompleteMix(preGroups);
-
-var remixCount = (int)(inputCount * remixRatio);
-var randomAmounts = Sample.Amounts.RandomElements(inputCount - remixCount).Select(x => x.ToSats()).Concat(preMix.SelectMany(x => x).RandomElements(remixCount));
-var inputGroups = randomAmounts.RandomGroups(userCount).ToArray();
-var mixer = new Mixer();
-var outputGroups = mixer.CompleteMix(inputGroups).Select(x => x.ToArray()).ToArray();
-
-if (inputGroups.SelectMany(x => x).Sum() <= outputGroups.SelectMany(x => x).Sum())
+for (int i = 0; i < 10000; i++)
 {
-    throw new InvalidOperationException("Bug. Transaction doesn't pay fees.");
+
+
+    var inputCount = 100;
+    var userCount = 30;
+    var remixRatio = 0.3;
+
+    var preRandomAmounts = Sample.Amounts.RandomElements(inputCount).Select(x => x.ToSats());
+    var preGroups = preRandomAmounts.RandomGroups(userCount);
+
+    var preMixer = new Mixer();
+    var preMix = preMixer.CompleteMix(preGroups);
+
+    var remixCount = (int)(inputCount * remixRatio);
+    var randomAmounts = Sample.Amounts.RandomElements(inputCount - remixCount).Select(x => x.ToSats()).Concat(preMix.SelectMany(x => x).RandomElements(remixCount));
+    var inputGroups = randomAmounts.RandomGroups(userCount).ToArray();
+    var mixer = new Mixer();
+    var outputGroups = mixer.CompleteMix(inputGroups).Select(x => x.ToArray()).ToArray();
+
+    if (inputGroups.SelectMany(x => x).Sum() <= outputGroups.SelectMany(x => x).Sum())
+    {
+        throw new InvalidOperationException("Bug. Transaction doesn't pay fees.");
+    }
+
+    var outputCount = outputGroups.Sum(x => x.Length);
+    var inputAmount = inputGroups.SelectMany(x => x).Sum();
+    var outputAmount = outputGroups.SelectMany(x => x).Sum();
+    var fee = inputAmount - outputAmount;
+    var size = inputCount * mixer.InputSize + outputCount * mixer.OutputSize;
+    var feeRate = (ulong)(fee / (decimal)size);
+
+    Console.WriteLine();
+
+    foreach (var (value, count, unique) in inputGroups
+        .GetIndistinguishable()
+        .OrderBy(x => x.value))
+    {
+        if (count == 1)
+        {
+            Console.ForegroundColor = ConsoleColor.Red;
+        }
+        var displayResult = count.ToString();
+        if (count != unique)
+        {
+            Console.ForegroundColor = ConsoleColor.Yellow;
+            displayResult = $"{unique}/{count} unique/total";
+        }
+        Console.WriteLine($"There are {displayResult} occurrences of\t{value / 100000000m} BTC input.");
+        Console.ForegroundColor = ConsoleColor.Gray;
+    }
+
+    Console.WriteLine();
+
+    foreach (var (value, count, unique) in outputGroups
+        .GetIndistinguishable()
+        .OrderBy(x => x.value))
+    {
+        if (count == 1)
+        {
+            Console.ForegroundColor = ConsoleColor.Red;
+        }
+        var displayResult = count.ToString();
+        if (count != unique)
+        {
+            Console.ForegroundColor = ConsoleColor.Yellow;
+            displayResult = $"{unique}/{count} unique/total";
+        }
+        Console.WriteLine($"There are {displayResult} occurrences of\t{value / 100000000m} BTC output.");
+        Console.ForegroundColor = ConsoleColor.Gray;
+    }
+
+    Console.WriteLine();
+    Console.WriteLine($"Number of users:\t{userCount}");
+    Console.WriteLine($"Number of inputs:\t{inputCount}");
+    Console.WriteLine($"Number of outputs:\t{outputCount}");
+    Console.WriteLine($"Total in:\t\t{inputAmount / 100000000m} BTC");
+    Console.WriteLine($"Fee paid:\t\t{fee / 100000000m} BTC");
+    Console.WriteLine($"Size:\t\t\t{size} vbyte");
+    Console.WriteLine($"Fee rate:\t\t{feeRate} sats/vbyte");
+    Console.WriteLine($"Average anonset:\t{Analyzer.AverageAnonsetGain(inputGroups, outputGroups):0.##}");
+    Console.WriteLine($"Average input anonset:\t{Analyzer.AverageAnonsetGain(inputGroups):0.##}");
+    Console.WriteLine($"Average output anonset:\t{Analyzer.AverageAnonsetGain(outputGroups):0.##}");
+    Console.WriteLine($"Blockspace efficiency:\t{Analyzer.BlockspaceEfficiency(inputGroups, outputGroups, size):0.##}");
+    Console.WriteLine($"Total leftover:\t\t{mixer.Leftovers.Sum():0}");
+    Console.WriteLine($"Average leftover:\t{mixer.Leftovers.Average():0}");
+    Console.WriteLine($"Median leftover:\t{mixer.Leftovers.Median():0}");
+    Console.WriteLine($"Largest leftover:\t{mixer.Leftovers.Max():0}");
 }
-
-var outputCount = outputGroups.Sum(x => x.Length);
-var inputAmount = inputGroups.SelectMany(x => x).Sum();
-var outputAmount = outputGroups.SelectMany(x => x).Sum();
-var fee = inputAmount - outputAmount;
-var size = inputCount * mixer.InputSize + outputCount * mixer.OutputSize;
-var feeRate = (ulong)(fee / (decimal)size);
-
-Console.WriteLine();
-
-foreach (var (value, count, unique) in inputGroups
-    .GetIndistinguishable()
-    .OrderBy(x => x.value))
-{
-    if (count == 1)
-    {
-        Console.ForegroundColor = ConsoleColor.Red;
-    }
-    var displayResult = count.ToString();
-    if (count != unique)
-    {
-        Console.ForegroundColor = ConsoleColor.Yellow;
-        displayResult = $"{unique}/{count} unique/total";
-    }
-    Console.WriteLine($"There are {displayResult} occurrences of\t{value / 100000000m} BTC input.");
-    Console.ForegroundColor = ConsoleColor.Gray;
-}
-
-Console.WriteLine();
-
-foreach (var (value, count, unique) in outputGroups
-    .GetIndistinguishable()
-    .OrderBy(x => x.value))
-{
-    if (count == 1)
-    {
-        Console.ForegroundColor = ConsoleColor.Red;
-    }
-    var displayResult = count.ToString();
-    if (count != unique)
-    {
-        Console.ForegroundColor = ConsoleColor.Yellow;
-        displayResult = $"{unique}/{count} unique/total";
-    }
-    Console.WriteLine($"There are {displayResult} occurrences of\t{value / 100000000m} BTC output.");
-    Console.ForegroundColor = ConsoleColor.Gray;
-}
-
-Console.WriteLine();
-Console.WriteLine($"Number of users:\t{userCount}");
-Console.WriteLine($"Number of inputs:\t{inputCount}");
-Console.WriteLine($"Number of outputs:\t{outputCount}");
-Console.WriteLine($"Total in:\t\t{inputAmount/100000000m} BTC");
-Console.WriteLine($"Fee paid:\t\t{fee / 100000000m} BTC");
-Console.WriteLine($"Size:\t\t\t{size} vbyte");
-Console.WriteLine($"Fee rate:\t\t{feeRate} sats/vbyte");
-Console.WriteLine($"Average anonset:\t{Analyzer.AverageAnonsetGain(inputGroups, outputGroups):0.##}");
-Console.WriteLine($"Average input anonset:\t{Analyzer.AverageAnonsetGain(inputGroups):0.##}");
-Console.WriteLine($"Average output anonset:\t{Analyzer.AverageAnonsetGain(outputGroups):0.##}");
-Console.WriteLine($"Blockspace efficiency:\t{Analyzer.BlockspaceEfficiency(inputGroups, outputGroups, size):0.##}");
-Console.WriteLine($"Total leftover:\t\t{mixer.Leftovers.Sum():0}");
-Console.WriteLine($"Average leftover:\t{mixer.Leftovers.Average():0}");
-Console.WriteLine($"Median leftover:\t{mixer.Leftovers.Median():0}");
-Console.WriteLine($"Largest leftover:\t{mixer.Leftovers.Max():0}");

--- a/Sake/Program.cs
+++ b/Sake/Program.cs
@@ -2,92 +2,87 @@
 using System;
 using System.Linq;
 
-for (int i = 0; i < 10000; i++)
+var inputCount = 100;
+var userCount = 30;
+var remixRatio = 0.3;
+
+var preRandomAmounts = Sample.Amounts.RandomElements(inputCount).Select(x => x.ToSats());
+var preGroups = preRandomAmounts.RandomGroups(userCount);
+
+var preMixer = new Mixer();
+var preMix = preMixer.CompleteMix(preGroups);
+
+var remixCount = (int)(inputCount * remixRatio);
+var randomAmounts = Sample.Amounts.RandomElements(inputCount - remixCount).Select(x => x.ToSats()).Concat(preMix.SelectMany(x => x).RandomElements(remixCount));
+var inputGroups = randomAmounts.RandomGroups(userCount).ToArray();
+var mixer = new Mixer();
+var outputGroups = mixer.CompleteMix(inputGroups).Select(x => x.ToArray()).ToArray();
+
+if (inputGroups.SelectMany(x => x).Sum() <= outputGroups.SelectMany(x => x).Sum())
 {
-
-
-    var inputCount = 100;
-    var userCount = 30;
-    var remixRatio = 0.3;
-
-    var preRandomAmounts = Sample.Amounts.RandomElements(inputCount).Select(x => x.ToSats());
-    var preGroups = preRandomAmounts.RandomGroups(userCount);
-
-    var preMixer = new Mixer();
-    var preMix = preMixer.CompleteMix(preGroups);
-
-    var remixCount = (int)(inputCount * remixRatio);
-    var randomAmounts = Sample.Amounts.RandomElements(inputCount - remixCount).Select(x => x.ToSats()).Concat(preMix.SelectMany(x => x).RandomElements(remixCount));
-    var inputGroups = randomAmounts.RandomGroups(userCount).ToArray();
-    var mixer = new Mixer();
-    var outputGroups = mixer.CompleteMix(inputGroups).Select(x => x.ToArray()).ToArray();
-
-    if (inputGroups.SelectMany(x => x).Sum() <= outputGroups.SelectMany(x => x).Sum())
-    {
-        throw new InvalidOperationException("Bug. Transaction doesn't pay fees.");
-    }
-
-    var outputCount = outputGroups.Sum(x => x.Length);
-    var inputAmount = inputGroups.SelectMany(x => x).Sum();
-    var outputAmount = outputGroups.SelectMany(x => x).Sum();
-    var fee = inputAmount - outputAmount;
-    var size = inputCount * mixer.InputSize + outputCount * mixer.OutputSize;
-    var feeRate = (ulong)(fee / (decimal)size);
-
-    Console.WriteLine();
-
-    foreach (var (value, count, unique) in inputGroups
-        .GetIndistinguishable()
-        .OrderBy(x => x.value))
-    {
-        if (count == 1)
-        {
-            Console.ForegroundColor = ConsoleColor.Red;
-        }
-        var displayResult = count.ToString();
-        if (count != unique)
-        {
-            Console.ForegroundColor = ConsoleColor.Yellow;
-            displayResult = $"{unique}/{count} unique/total";
-        }
-        Console.WriteLine($"There are {displayResult} occurrences of\t{value / 100000000m} BTC input.");
-        Console.ForegroundColor = ConsoleColor.Gray;
-    }
-
-    Console.WriteLine();
-
-    foreach (var (value, count, unique) in outputGroups
-        .GetIndistinguishable()
-        .OrderBy(x => x.value))
-    {
-        if (count == 1)
-        {
-            Console.ForegroundColor = ConsoleColor.Red;
-        }
-        var displayResult = count.ToString();
-        if (count != unique)
-        {
-            Console.ForegroundColor = ConsoleColor.Yellow;
-            displayResult = $"{unique}/{count} unique/total";
-        }
-        Console.WriteLine($"There are {displayResult} occurrences of\t{value / 100000000m} BTC output.");
-        Console.ForegroundColor = ConsoleColor.Gray;
-    }
-
-    Console.WriteLine();
-    Console.WriteLine($"Number of users:\t{userCount}");
-    Console.WriteLine($"Number of inputs:\t{inputCount}");
-    Console.WriteLine($"Number of outputs:\t{outputCount}");
-    Console.WriteLine($"Total in:\t\t{inputAmount / 100000000m} BTC");
-    Console.WriteLine($"Fee paid:\t\t{fee / 100000000m} BTC");
-    Console.WriteLine($"Size:\t\t\t{size} vbyte");
-    Console.WriteLine($"Fee rate:\t\t{feeRate} sats/vbyte");
-    Console.WriteLine($"Average anonset:\t{Analyzer.AverageAnonsetGain(inputGroups, outputGroups):0.##}");
-    Console.WriteLine($"Average input anonset:\t{Analyzer.AverageAnonsetGain(inputGroups):0.##}");
-    Console.WriteLine($"Average output anonset:\t{Analyzer.AverageAnonsetGain(outputGroups):0.##}");
-    Console.WriteLine($"Blockspace efficiency:\t{Analyzer.BlockspaceEfficiency(inputGroups, outputGroups, size):0.##}");
-    Console.WriteLine($"Total leftover:\t\t{mixer.Leftovers.Sum():0}");
-    Console.WriteLine($"Average leftover:\t{mixer.Leftovers.Average():0}");
-    Console.WriteLine($"Median leftover:\t{mixer.Leftovers.Median():0}");
-    Console.WriteLine($"Largest leftover:\t{mixer.Leftovers.Max():0}");
+    throw new InvalidOperationException("Bug. Transaction doesn't pay fees.");
 }
+
+var outputCount = outputGroups.Sum(x => x.Length);
+var inputAmount = inputGroups.SelectMany(x => x).Sum();
+var outputAmount = outputGroups.SelectMany(x => x).Sum();
+var fee = inputAmount - outputAmount;
+var size = inputCount * mixer.InputSize + outputCount * mixer.OutputSize;
+var feeRate = (ulong)(fee / (decimal)size);
+
+Console.WriteLine();
+
+foreach (var (value, count, unique) in inputGroups
+    .GetIndistinguishable()
+    .OrderBy(x => x.value))
+{
+    if (count == 1)
+    {
+        Console.ForegroundColor = ConsoleColor.Red;
+    }
+    var displayResult = count.ToString();
+    if (count != unique)
+    {
+        Console.ForegroundColor = ConsoleColor.Yellow;
+        displayResult = $"{unique}/{count} unique/total";
+    }
+    Console.WriteLine($"There are {displayResult} occurrences of\t{value / 100000000m} BTC input.");
+    Console.ForegroundColor = ConsoleColor.Gray;
+}
+
+Console.WriteLine();
+
+foreach (var (value, count, unique) in outputGroups
+    .GetIndistinguishable()
+    .OrderBy(x => x.value))
+{
+    if (count == 1)
+    {
+        Console.ForegroundColor = ConsoleColor.Red;
+    }
+    var displayResult = count.ToString();
+    if (count != unique)
+    {
+        Console.ForegroundColor = ConsoleColor.Yellow;
+        displayResult = $"{unique}/{count} unique/total";
+    }
+    Console.WriteLine($"There are {displayResult} occurrences of\t{value / 100000000m} BTC output.");
+    Console.ForegroundColor = ConsoleColor.Gray;
+}
+
+Console.WriteLine();
+Console.WriteLine($"Number of users:\t{userCount}");
+Console.WriteLine($"Number of inputs:\t{inputCount}");
+Console.WriteLine($"Number of outputs:\t{outputCount}");
+Console.WriteLine($"Total in:\t\t{inputAmount / 100000000m} BTC");
+Console.WriteLine($"Fee paid:\t\t{fee / 100000000m} BTC");
+Console.WriteLine($"Size:\t\t\t{size} vbyte");
+Console.WriteLine($"Fee rate:\t\t{feeRate} sats/vbyte");
+Console.WriteLine($"Average anonset:\t{Analyzer.AverageAnonsetGain(inputGroups, outputGroups):0.##}");
+Console.WriteLine($"Average input anonset:\t{Analyzer.AverageAnonsetGain(inputGroups):0.##}");
+Console.WriteLine($"Average output anonset:\t{Analyzer.AverageAnonsetGain(outputGroups):0.##}");
+Console.WriteLine($"Blockspace efficiency:\t{Analyzer.BlockspaceEfficiency(inputGroups, outputGroups, size):0.##}");
+Console.WriteLine($"Total leftover:\t\t{mixer.Leftovers.Sum():0}");
+Console.WriteLine($"Average leftover:\t{mixer.Leftovers.Average():0}");
+Console.WriteLine($"Median leftover:\t{mixer.Leftovers.Median():0}");
+Console.WriteLine($"Largest leftover:\t{mixer.Leftovers.Max():0}");

--- a/Sake/Program.cs
+++ b/Sake/Program.cs
@@ -26,6 +26,7 @@ if (inputGroups.SelectMany(x => x).Sum() <= outputGroups.SelectMany(x => x).Sum(
 var outputCount = outputGroups.Sum(x => x.Length);
 var inputAmount = inputGroups.SelectMany(x => x).Sum();
 var outputAmount = outputGroups.SelectMany(x => x).Sum();
+var changeCount = outputGroups.SelectMany(x => x).GetIndistinguishable(includeSingle: true).Count(x => x.count == 1);
 var fee = inputAmount - outputAmount;
 var size = inputCount * mixer.InputSize + outputCount * mixer.OutputSize;
 var feeRate = (ulong)(fee / (decimal)size);
@@ -74,6 +75,7 @@ Console.WriteLine();
 Console.WriteLine($"Number of users:\t{userCount}");
 Console.WriteLine($"Number of inputs:\t{inputCount}");
 Console.WriteLine($"Number of outputs:\t{outputCount}");
+Console.WriteLine($"Number of changes:\t{changeCount:0}");
 Console.WriteLine($"Total in:\t\t{inputAmount / 100000000m} BTC");
 Console.WriteLine($"Fee paid:\t\t{fee / 100000000m} BTC");
 Console.WriteLine($"Size:\t\t\t{size} vbyte");
@@ -83,6 +85,5 @@ Console.WriteLine($"Average input anonset:\t{Analyzer.AverageAnonsetGain(inputGr
 Console.WriteLine($"Average output anonset:\t{Analyzer.AverageAnonsetGain(outputGroups):0.##}");
 Console.WriteLine($"Blockspace efficiency:\t{Analyzer.BlockspaceEfficiency(inputGroups, outputGroups, size):0.##}");
 Console.WriteLine($"Total leftover:\t\t{mixer.Leftovers.Sum():0}");
-Console.WriteLine($"Average leftover:\t{mixer.Leftovers.Average():0}");
 Console.WriteLine($"Median leftover:\t{mixer.Leftovers.Median():0}");
 Console.WriteLine($"Largest leftover:\t{mixer.Leftovers.Max():0}");


### PR DESCRIPTION
Putting https://github.com/nopara73/Sake/pull/2 into its place.

@lontivero I've been playing around with this and I noticed it does not work at all. The algorithm always finds the naive decomposition and nothing else. It finds it a number of times (that's why I added back the hashcode uniqueness check to make sure and it turns out it's true.) Can you take a look what's going on?