### PR TITLE
Validate arguments

### DIFF
--- a/Sake/DecomposeMixer.cs
+++ b/Sake/DecomposeMixer.cs
@@ -1,4 +1,4 @@
-﻿namespace Sake;
+namespace Sake;
 
 /// <summary>
 /// https://github.com/lontivero/DecompositionsPlayground/blob/master/Notebook.ipynb
@@ -9,9 +9,22 @@ public static class Decomposer
 
 	public static IEnumerable<(long Sum, int Count, ulong Decomposition)> Decompose(long target, long tolerance, int maxCount)
 	{
+		if (maxCount is <= 1 or > 8)
+		{
+			throw new ArgumentOutOfRangeException(nameof(maxCount), "The maximum decomposition lenght cannot be greater than 8 or smaller than 1.");
+		}
+		if (target <= 0)
+		{
+			throw new ArgumentException("Only possitive numbers can be decomposed.", nameof(target));
+		}
+
 		var denoms = StdDenoms.SkipWhile(x => x > target).ToArray();
 
-		return denoms.SelectMany((_, i) => InternalCombinations(target, tolerance: tolerance / 10, maxCount, denoms)).Take(10000).ToList();
+		if (denoms.Length > 255)
+		{
+			throw new ArgumentException("Too many denominations. Maximum number is 256.", nameof(target));
+		}
+		return denoms.SelectMany((_, i) => InternalCombinations(target, tolerance: tolerance, maxCount, denoms)).Take(10000).ToList();
 	}
 
 	private static IEnumerable<(long Sum, int Count, ulong Decomposition)> InternalCombinations(long target, long tolerance, int maxLength, long[] denoms)

--- a/Sake/DecomposeMixer.cs
+++ b/Sake/DecomposeMixer.cs
@@ -1,4 +1,4 @@
-namespace Sake;
+﻿namespace Sake;
 
 /// <summary>
 /// https://github.com/lontivero/DecompositionsPlayground/blob/master/Notebook.ipynb
@@ -51,7 +51,7 @@ public static class Decomposer
 					.TakeUntil(x => x.Sum == target));
 		}
 
-		return denoms.SelectMany((_, i) => Combinations(i, 0ul, 0, maxLength - 1)).Take(500).ToList();
+		return denoms.SelectMany((_, i) => Combinations(i, 0ul, 0, maxLength - 1)).Take(5000).ToList();
 	}
 
 	private static int Search(long value, long[] denoms, int offset)

--- a/Sake/Mixer.cs
+++ b/Sake/Mixer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -269,13 +269,6 @@ namespace Sake
                 foreach (var item in currentSet.OrderBy(x => x))
                 {
                     hash.Add(item);
-                }
-
-                // Add change output if necessary.
-                var diff = (ulong)sum - currentSet.Sum();
-                if (diff > MinAllowedOutputAmountPlusFee)
-                {
-                    currentSet.Add(diff);
                 }
                 setCandidates.TryAdd(hash.ToHashCode(), (currentSet, myInputSum - (ulong)currentSet.Sum() + (ulong)count * OutputFee)); // The cost is the remaining + output cost.
             }

--- a/Sake/Mixer.cs
+++ b/Sake/Mixer.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -258,7 +258,7 @@ namespace Sake
 
             // Create many decompositions for optimization.
             Decomposer.StdDenoms = denoms.Where(x => x <= myInputSum).Select(x => (long)x).ToArray();
-            foreach (var (sum, count, decomp) in Decomposer.Decompose((long)myInputSum, (long)loss, Math.Min(10, Math.Max(5, naiveSet.Count))))
+            foreach (var (sum, count, decomp) in Decomposer.Decompose((long)myInputSum, (long)loss, Math.Min(8, Math.Max(5, naiveSet.Count))))
             {
                 var currentSet = Decomposer.ToRealValuesArray(
                     decomp,

--- a/Sake/Mixer.cs
+++ b/Sake/Mixer.cs
@@ -258,7 +258,7 @@ namespace Sake
 
             // Create many decompositions for optimization.
             Decomposer.StdDenoms = denoms.Where(x => x <= myInputSum).Select(x => (long)x).ToArray();
-            foreach (var (sum, count, decomp) in Decomposer.Decompose((long)myInputSum, (long)loss, Math.Min(8, Math.Max(5, naiveSet.Count))))
+            foreach (var (sum, count, decomp) in Decomposer.Decompose((long)myInputSum, (long)Math.Max(loss, 0.5 * MinAllowedOutputAmountPlusFee) , Math.Min(8, Math.Max(5, naiveSet.Count))))
             {
                 var currentSet = Decomposer.ToRealValuesArray(
                     decomp,


### PR DESCRIPTION
This PR validates the argument we pass to the decomposer in order to prevent to operate with invalid values and generate garbage.

Given the decomposer doesn't generate more than a few tens of result in the best cases then here we increase the deep of the search a significantly without affecting the performence.

Finally, when the naive decomposition loses only a few sats then it is hard to find even better solutions without exhausting the space of results so, here in those cases the tolerance is the max(naive.loss, minAllowLoss / 2)

