### PR TITLE
Add sanity check for output decomp

### DIFF
--- a/Sake/Mixer.cs
+++ b/Sake/Mixer.cs
@@ -223,6 +223,12 @@ namespace Sake
             var smallestScriptType = Math.Min(ScriptType.P2WPKH.EstimateOutputVsize(), ScriptType.Taproot.EstimateOutputVsize());
             var maxNumberOfOutputsAllowed = Math.Min(availableVsize / smallestScriptType, 10); // The absolute max possible with the smallest script type.
 
+            // If my input sum is smaller than the smallest denomination, then participation in a coinjoin makes no sense.
+            if (denoms.Min(x => x.EffectiveCost) > myInputSum)
+            {
+                throw new InvalidOperationException("Not enough coins registered to participate in the coinjoin.");
+            }
+
             var setCandidates = new Dictionary<int, (IEnumerable<Output> Decomp, Money Cost)>();
 
             // Create the most naive decomposition for starter.


### PR DESCRIPTION
Explanation: https://github.com/zkSNACKs/WalletWasabi/issues/10759#issuecomment-1569910313

Draft, because Part 2 isn't yet implemented (that must be implemented to WalletWasabi not here)