### PR TITLE
FIx stop condition for naive and pre-decomposer

### DIFF
--- a/Sake/Mixer.cs
+++ b/Sake/Mixer.cs
@@ -39,8 +39,6 @@ namespace Sake
         }
 
         public ScriptType ChangeScriptType { get; }
-        public Money ChangeFee => FeeRate.GetFee(ChangeScriptType.EstimateOutputVsize());
-
         public Money MinAllowedOutputAmount { get; }
         public Money MaxAllowedOutputAmount { get; }
         private Random Random { get; }

--- a/Sake/Mixer.cs
+++ b/Sake/Mixer.cs
@@ -29,7 +29,7 @@ namespace Sake
                 Math.Max(
                     ScriptType.P2WPKH.EstimateInputVsize() + ScriptType.P2WPKH.EstimateOutputVsize(),
                     ScriptType.Taproot.EstimateInputVsize() + ScriptType.Taproot.EstimateOutputVsize()));
-            MinAllowedOutputAmount = Math.Max(3 * minEconomicalOutput, minAllowedOutputAmount);
+            MinAllowedOutputAmount = Math.Max(minEconomicalOutput, minAllowedOutputAmount);
             MaxAllowedOutputAmount = maxAllowedOutputAmount;
             Random = random ?? Random.Shared;
 

--- a/Sake/Program.cs
+++ b/Sake/Program.cs
@@ -12,7 +12,7 @@ for (int i = 0; i < 100; i++)
 
     var min = Money.Satoshis(5000m);
     var max = Money.Coins(43000m);
-    var feeRate = new FeeRate(10m);
+    var feeRate = new FeeRate(200m);
     var random = new Random();
 
     var maxInputCost = Money.Satoshis(Math.Max(NBitcoinExtensions.P2wpkhInputVirtualSize, NBitcoinExtensions.P2trInputVirtualSize) * feeRate.SatoshiPerByte);


### PR DESCRIPTION
Based on #35 
See changes: 2346f20890f465d865920517cd881d727a8e03eb
Addresses https://github.com/nopara73/Sake/pull/31#issuecomment-1567618018 and https://github.com/nopara73/Sake/pull/31#issuecomment-1570829563

The comments in the code should be self-explanatory, but basically the idea is that we don't need to have vSize available for the change if it's not possible to have change (because the remaining is lower than the effective amount of the output + the min allowed output amount (for the change) + the `ChangeFee`)