### PR TITLE
Verify that sum of inputs is > than min output denom

### DIFF
--- a/Sake/DenominationBuilder.cs
+++ b/Sake/DenominationBuilder.cs
@@ -19,7 +19,7 @@ namespace Sake
             {
                 var denom = CreateDenom(Math.Pow(2, i));
 
-                if (denom.EffectiveAmount < minAllowedOutputAmount)
+                if (denom.Amount < minAllowedOutputAmount)
                 {
                     continue;
                 }
@@ -37,7 +37,7 @@ namespace Sake
             {
                 var denom = CreateDenom(Math.Pow(3, i));
 
-                if (denom.EffectiveAmount < minAllowedOutputAmount)
+                if (denom.Amount < minAllowedOutputAmount)
                 {
                     continue;
                 }
@@ -55,7 +55,7 @@ namespace Sake
             {
                 var denom = CreateDenom(Math.Pow(3, i) * 2);
 
-                if (denom.EffectiveAmount < minAllowedOutputAmount)
+                if (denom.Amount < minAllowedOutputAmount)
                 {
                     continue;
                 }
@@ -73,7 +73,7 @@ namespace Sake
             {
                 var denom = CreateDenom(Math.Pow(10, i));
 
-                if (denom.EffectiveAmount < minAllowedOutputAmount)
+                if (denom.Amount < minAllowedOutputAmount)
                 {
                     continue;
                 }
@@ -91,7 +91,7 @@ namespace Sake
             {
                 var denom = CreateDenom(Math.Pow(10, i) * 2);
 
-                if (denom.EffectiveAmount < minAllowedOutputAmount)
+                if (denom.Amount < minAllowedOutputAmount)
                 {
                     continue;
                 }
@@ -109,7 +109,7 @@ namespace Sake
             {
                 var denom = CreateDenom(Math.Pow(10, i) * 5);
 
-                if (denom.EffectiveAmount < minAllowedOutputAmount)
+                if (denom.Amount < minAllowedOutputAmount)
                 {
                     continue;
                 }

--- a/Sake/DenominationBuilder.cs
+++ b/Sake/DenominationBuilder.cs
@@ -4,7 +4,7 @@ namespace Sake
 {
     public static class DenominationBuilder
     {
-        public static IOrderedEnumerable<Output> CreateDenominations(Money minAllowedOutputEffectiveCost, Money maxAllowedOutputAmount, FeeRate feeRate, IEnumerable<ScriptType> allowedOutputTypes, Random random)
+        public static IOrderedEnumerable<Output> CreateDenominations(Money minAllowedOutputAmount, Money maxAllowedOutputAmount, FeeRate feeRate, IEnumerable<ScriptType> allowedOutputTypes, Random random)
         {
             var denominations = new HashSet<Output>();
 
@@ -19,7 +19,7 @@ namespace Sake
             {
                 var denom = CreateDenom(Math.Pow(2, i));
 
-                if (denom.EffectiveAmount < minAllowedOutputEffectiveCost)
+                if (denom.EffectiveAmount < minAllowedOutputAmount)
                 {
                     continue;
                 }
@@ -37,7 +37,7 @@ namespace Sake
             {
                 var denom = CreateDenom(Math.Pow(3, i));
 
-                if (denom.EffectiveAmount < minAllowedOutputEffectiveCost)
+                if (denom.EffectiveAmount < minAllowedOutputAmount)
                 {
                     continue;
                 }
@@ -55,7 +55,7 @@ namespace Sake
             {
                 var denom = CreateDenom(Math.Pow(3, i) * 2);
 
-                if (denom.EffectiveAmount < minAllowedOutputEffectiveCost)
+                if (denom.EffectiveAmount < minAllowedOutputAmount)
                 {
                     continue;
                 }
@@ -73,7 +73,7 @@ namespace Sake
             {
                 var denom = CreateDenom(Math.Pow(10, i));
 
-                if (denom.EffectiveAmount < minAllowedOutputEffectiveCost)
+                if (denom.EffectiveAmount < minAllowedOutputAmount)
                 {
                     continue;
                 }
@@ -91,7 +91,7 @@ namespace Sake
             {
                 var denom = CreateDenom(Math.Pow(10, i) * 2);
 
-                if (denom.EffectiveAmount < minAllowedOutputEffectiveCost)
+                if (denom.EffectiveAmount < minAllowedOutputAmount)
                 {
                     continue;
                 }
@@ -109,7 +109,7 @@ namespace Sake
             {
                 var denom = CreateDenom(Math.Pow(10, i) * 5);
 
-                if (denom.EffectiveAmount < minAllowedOutputEffectiveCost)
+                if (denom.EffectiveAmount < minAllowedOutputAmount)
                 {
                     continue;
                 }

--- a/Sake/DenominationBuilder.cs
+++ b/Sake/DenominationBuilder.cs
@@ -4,7 +4,7 @@ namespace Sake
 {
     public static class DenominationBuilder
     {
-        public static IOrderedEnumerable<Output> CreateDenominations(Money minAllowedOutputAmount, Money maxAllowedOutputAmount, FeeRate feeRate, IEnumerable<ScriptType> allowedOutputTypes, Random random)
+        public static IOrderedEnumerable<Output> CreateDenominations(Money minAllowedOutputEffectiveCost, Money maxAllowedOutputAmount, FeeRate feeRate, IEnumerable<ScriptType> allowedOutputTypes, Random random)
         {
             var denominations = new HashSet<Output>();
 
@@ -19,7 +19,7 @@ namespace Sake
             {
                 var denom = CreateDenom(Math.Pow(2, i));
 
-                if (denom.Amount < minAllowedOutputAmount)
+                if (denom.EffectiveAmount < minAllowedOutputEffectiveCost)
                 {
                     continue;
                 }
@@ -37,7 +37,7 @@ namespace Sake
             {
                 var denom = CreateDenom(Math.Pow(3, i));
 
-                if (denom.Amount < minAllowedOutputAmount)
+                if (denom.EffectiveAmount < minAllowedOutputEffectiveCost)
                 {
                     continue;
                 }
@@ -55,7 +55,7 @@ namespace Sake
             {
                 var denom = CreateDenom(Math.Pow(3, i) * 2);
 
-                if (denom.Amount < minAllowedOutputAmount)
+                if (denom.EffectiveAmount < minAllowedOutputEffectiveCost)
                 {
                     continue;
                 }
@@ -73,7 +73,7 @@ namespace Sake
             {
                 var denom = CreateDenom(Math.Pow(10, i));
 
-                if (denom.Amount < minAllowedOutputAmount)
+                if (denom.EffectiveAmount < minAllowedOutputEffectiveCost)
                 {
                     continue;
                 }
@@ -91,7 +91,7 @@ namespace Sake
             {
                 var denom = CreateDenom(Math.Pow(10, i) * 2);
 
-                if (denom.Amount < minAllowedOutputAmount)
+                if (denom.EffectiveAmount < minAllowedOutputEffectiveCost)
                 {
                     continue;
                 }
@@ -109,7 +109,7 @@ namespace Sake
             {
                 var denom = CreateDenom(Math.Pow(10, i) * 5);
 
-                if (denom.Amount < minAllowedOutputAmount)
+                if (denom.EffectiveAmount < minAllowedOutputEffectiveCost)
                 {
                     continue;
                 }

--- a/Sake/Display.cs
+++ b/Sake/Display.cs
@@ -11,6 +11,7 @@ public static class Display
 	    }
 	    Console.WriteLine($"Number of users:\t{results.Median(r => r.UserCount):0.##}");
 	    Console.WriteLine($"Number of inputs:\t{results.Median(r => r.InputCount):0.##}");
+	    Console.WriteLine($"Inputs added:\t\t{results.Median(r => r.DiffInputNumber):0.##}");
 	    Console.WriteLine($"Number of outputs:\t{results.Median(r => r.OutputCount):0.##}");
 	    Console.WriteLine($"Number of changes:\t{results.Average(r => r.ChangeCount):0.##}");
 	    Console.WriteLine($"Total in:\t\t{(decimal)(results.Median(r => (double)r.InputAmount) ?? 0) / 100000000m} BTC");

--- a/Sake/Mixer.cs
+++ b/Sake/Mixer.cs
@@ -87,7 +87,7 @@ namespace Sake
                 }
                 
                 // If my input sum is smaller than the smallest denomination, then participation in a coinjoin makes no sense.
-                if (filteredDenominations.Min(x => x.EffectiveCost) > currentUser.Select(x => x.EffectiveValue).Sum())
+                if (MinAllowedOutputAmount + ChangeFee > currentUser.Select(x => x.EffectiveValue).Sum())
                 {
                     throw new InvalidOperationException("Not enough coins registered to participate in the coinjoin.");
                 }
@@ -487,7 +487,7 @@ namespace Sake
                     feeRate,
                     new List<ScriptType>() { maxVsizeInputOutputPairScriptType },
                     Random)
-                .Min(x => x.EffectiveCost);
+                .Min(x => x.Amount);
 
             return smallestEffectiveDenom is null
                 ? throw new InvalidOperationException("Something's wrong with the denomination creation or with the parameters it got.")

--- a/Sake/Mixer.cs
+++ b/Sake/Mixer.cs
@@ -488,6 +488,7 @@ namespace Sake
                     feeRate,
                     new List<ScriptType>() { maxVsizeInputOutputPairScriptType },
                     Random)
+                .Where(x => x.EffectiveAmount >= minReasonableOutputAmount)
                 .Min(x => x.EffectiveCost);
 
             return smallestEffectiveDenom is null

--- a/Sake/Mixer.cs
+++ b/Sake/Mixer.cs
@@ -487,7 +487,6 @@ namespace Sake
                     feeRate,
                     new List<ScriptType>() { maxVsizeInputOutputPairScriptType },
                     Random)
-                .Where(x => x.EffectiveAmount >= minReasonableOutputAmount)
                 .Min(x => x.EffectiveCost);
 
             return smallestEffectiveDenom is null

--- a/Sake/Program.cs
+++ b/Sake/Program.cs
@@ -13,19 +13,26 @@ for (int i = 0; i < 100; i++)
 
     var min = Money.Satoshis(5000m);
     var max = Money.Coins(43000m);
-    var feeRate = new FeeRate(200m);
+    var feeRate = new FeeRate(2000m);
     var random = new Random();
 
     var maxInputCost = Money.Satoshis(Math.Max(NBitcoinExtensions.P2wpkhInputVirtualSize, NBitcoinExtensions.P2trInputVirtualSize) * feeRate.SatoshiPerByte);
-
+    
+    var preMixer = new Mixer(feeRate, min, max, allowedOutputTypes, random); 
+    var (minDenom, maxDenom) = preMixer.CalculateReasonableOutputAmountRange();
+    
+    Func<Money, bool> userGroupsPredicate = (sumOfEffectiveValue =>
+        sumOfEffectiveValue >= minDenom &&
+        sumOfEffectiveValue <= maxDenom);
+    
     // Don't select inputs that costs more to spend than their value. This is what happens in SelectCoinsForRound.
     var preRandomAmounts = Sample.Amounts
         .Where(x => Money.Coins(x) > maxInputCost)
         .RandomElements(inputCount)
         .Select(x => new Input(Money.Coins(x), allowedOutputTypes.RandomElement(random), feeRate));
-
-    var preGroups = preRandomAmounts.RandomGroups(userCount);
-    var preMixer = new Mixer(feeRate, min, max, allowedOutputTypes, random);
+    
+    var preGroups = preRandomAmounts.RandomGroups(userCount).Where(x => userGroupsPredicate(x.Sum(y => y.Amount)));
+    
     var preMix = preMixer.CompleteMix(preGroups);
 
     var remixCount = (int)(inputCount * remixRatio);
@@ -39,10 +46,13 @@ for (int i = 0; i < 100; i++)
         .Where(x => Money.Satoshis(x) > maxInputCost)
         .RandomElements(remixCount)
         .Select(x => new Input(Money.Satoshis(x), allowedOutputTypes.RandomElement(random), feeRate));
+    
+    var mixer = new Mixer(feeRate, min, max, allowedOutputTypes, random);
+    (minDenom, maxDenom) = mixer.CalculateReasonableOutputAmountRange();
+    
 
     var newRoundAmounts = randomAmounts.Concat(remixAmounts);
-    var newRoundInputGroups = newRoundAmounts.RandomGroups(userCount).ToArray();
-    var mixer = new Mixer(feeRate, min, max, allowedOutputTypes, random);
+    var newRoundInputGroups = newRoundAmounts.RandomGroups(userCount).Where(x => userGroupsPredicate(x.Sum(y => y.Amount))).ToArray();
     var outputGroups = mixer.CompleteMix(newRoundInputGroups).Select(x => x.ToArray()).ToArray();
 
     if ((ulong)newRoundInputGroups.SelectMany(x => x).Sum(x => x.EffectiveValue) <= outputGroups.SelectMany(x => x).Sum())
@@ -101,8 +111,8 @@ for (int i = 0; i < 100; i++)
     }
 
     var result = new SimulationResult(
-        userCount,
-        inputCount,
+        newRoundInputGroups.Count(),
+        newRoundInputGroups.SelectMany(x => x).Count(),
         outputCount,
         changeCount,
         inputAmount,

--- a/Sake/Program.cs
+++ b/Sake/Program.cs
@@ -56,9 +56,14 @@ for (int i = 0; i < 100; i++)
 
     // Make sure we have the correct number of inputs
     var diffInputNumber = inputCount - newRoundInputGroups.SelectMany(x => x).Count();
-    for (var j = 0; j < diffInputNumber; j++)
+    if (diffInputNumber > 0)
     {
-        newRoundInputGroups.MinBy(x => x.Count)!.Add(remixAmounts.RandomElement(random));
+        newRoundInputGroups = newRoundInputGroups.OrderBy(x => x.Count).ToArray();
+        var randomElements = remixAmounts.RandomElements(diffInputNumber).ToArray();
+        for (var j = 0; j < diffInputNumber; j++)
+        {
+            newRoundInputGroups[j % newRoundInputGroups.Length].Add(randomElements[j]);
+        }
     }
     
     var outputGroups = mixer.CompleteMix(newRoundInputGroups).Select(x => x.ToArray()).ToArray();

--- a/Sake/Program.cs
+++ b/Sake/Program.cs
@@ -31,7 +31,7 @@ for (int i = 0; i < 100; i++)
         .RandomElements(inputCount)
         .Select(x => new Input(Money.Coins(x), allowedOutputTypes.RandomElement(random), feeRate));
     
-    var preGroups = preRandomAmounts.RandomGroups(userCount).Where(x => userGroupsPredicate(x.Sum(y => y.Amount)));
+    var preGroups = preRandomAmounts.RandomGroups(userCount).Where(x => userGroupsPredicate(x.Sum(y => y.EffectiveValue)));
     
     var preMix = preMixer.CompleteMix(preGroups);
 
@@ -52,7 +52,7 @@ for (int i = 0; i < 100; i++)
     
 
     var newRoundAmounts = randomAmounts.Concat(remixAmounts);
-    var newRoundInputGroups = newRoundAmounts.RandomGroups(userCount).Where(x => userGroupsPredicate(x.Sum(y => y.Amount))).ToArray();
+    var newRoundInputGroups = newRoundAmounts.RandomGroups(userCount).Where(x => userGroupsPredicate(x.Sum(y => y.EffectiveValue))).ToArray();
     var outputGroups = mixer.CompleteMix(newRoundInputGroups).Select(x => x.ToArray()).ToArray();
 
     if ((ulong)newRoundInputGroups.SelectMany(x => x).Sum(x => x.EffectiveValue) <= outputGroups.SelectMany(x => x).Sum())

--- a/Sake/Program.cs
+++ b/Sake/Program.cs
@@ -13,7 +13,7 @@ for (int i = 0; i < 100; i++)
 
     var min = Money.Satoshis(5000m);
     var max = Money.Coins(43000m);
-    var feeRate = new FeeRate(2000m);
+    var feeRate = new FeeRate(20m);
     var random = new Random();
 
     var maxInputCost = Money.Satoshis(Math.Max(NBitcoinExtensions.P2wpkhInputVirtualSize, NBitcoinExtensions.P2trInputVirtualSize) * feeRate.SatoshiPerByte);

--- a/Sake/Program.cs
+++ b/Sake/Program.cs
@@ -13,7 +13,7 @@ for (int i = 0; i < 100; i++)
 
     var min = Money.Satoshis(5000m);
     var max = Money.Coins(43000m);
-    var feeRate = new FeeRate(20m);
+    var feeRate = new FeeRate(200m);
     var random = new Random();
 
     var maxInputCost = Money.Satoshis(Math.Max(NBitcoinExtensions.P2wpkhInputVirtualSize, NBitcoinExtensions.P2trInputVirtualSize) * feeRate.SatoshiPerByte);

--- a/Sake/Program.cs
+++ b/Sake/Program.cs
@@ -52,7 +52,15 @@ for (int i = 0; i < 100; i++)
     
 
     var newRoundAmounts = randomAmounts.Concat(remixAmounts);
-    var newRoundInputGroups = newRoundAmounts.RandomGroups(userCount).Where(x => userGroupsPredicate(x.Sum(y => y.EffectiveValue))).ToArray();
+    var newRoundInputGroups = newRoundAmounts.RandomGroups(userCount).Where(x => userGroupsPredicate(x.Sum(y => y.EffectiveValue))).Select(x => x.ToList()).ToArray();
+
+    // Make sure we have the correct number of inputs
+    var diffInputNumber = inputCount - newRoundInputGroups.SelectMany(x => x).Count();
+    for (var j = 0; j < diffInputNumber; j++)
+    {
+        newRoundInputGroups.MinBy(x => x.Count)!.Add(remixAmounts.RandomElement(random));
+    }
+    
     var outputGroups = mixer.CompleteMix(newRoundInputGroups).Select(x => x.ToArray()).ToArray();
 
     if ((ulong)newRoundInputGroups.SelectMany(x => x).Sum(x => x.EffectiveValue) <= outputGroups.SelectMany(x => x).Sum())
@@ -111,8 +119,9 @@ for (int i = 0; i < 100; i++)
     }
 
     var result = new SimulationResult(
-        newRoundInputGroups.Count(),
-        newRoundInputGroups.SelectMany(x => x).Count(),
+        userCount,
+        inputCount,
+        diffInputNumber,
         outputCount,
         changeCount,
         inputAmount,

--- a/Sake/Program.cs
+++ b/Sake/Program.cs
@@ -62,7 +62,7 @@ for (int i = 0; i < 100; i++)
         var randomElements = remixAmounts.RandomElements(diffInputNumber).ToArray();
         for (var j = 0; j < diffInputNumber; j++)
         {
-            newRoundInputGroups[j % newRoundInputGroups.Length].Add(randomElements[j]);
+            newRoundInputGroups[j % newRoundInputGroups.Length].Add(randomElements[j % randomElements.Length]);
         }
     }
     

--- a/Sake/SimulationResult.cs
+++ b/Sake/SimulationResult.cs
@@ -4,6 +4,7 @@ public class SimulationResult
 {
     public int UserCount { get; }
     public int InputCount { get; }
+    public int DiffInputNumber { get; }
     public int OutputCount { get; }
     public int ChangeCount { get; }
     public ulong InputAmount { get; }
@@ -25,6 +26,7 @@ public class SimulationResult
     public SimulationResult(
         int userCount,
         int inputCount,
+        int diffInputNumber,
         int outputCount,
         int changeCount,
         ulong inputAmount,
@@ -49,6 +51,7 @@ public class SimulationResult
         OutputCount = outputCount;
         ChangeCount = changeCount;
         InputAmount = inputAmount;
+        DiffInputNumber = diffInputNumber;
         FeeInputs = feeInputs;
         FeeOutputs = feeOutputs;
         TotalFee = totalFee;


### PR DESCRIPTION
https://github.com/zkSNACKs/WalletWasabi/pull/10842

This PR doesn't add new inputs to the second mix if some groups created are below the economical threshold (option 3 in my [comment](https://github.com/nopara73/Sake/pull/39#issuecomment-1585292732) on the other PR).