### PR TITLE
Add inputs if there are not enough outputs to respect remix rate.

### DIFF
--- a/Sake/Display.cs
+++ b/Sake/Display.cs
@@ -11,6 +11,7 @@ public static class Display
 	    }
 	    Console.WriteLine($"Number of users:\t{results.Median(r => r.UserCount):0.##}");
 	    Console.WriteLine($"Number of inputs:\t{results.Median(r => r.InputCount):0.##}");
+	    Console.WriteLine($"Number of inputs added:\t{results.Median(r => r.InputAddedCount):0.##}");
 	    Console.WriteLine($"Number of outputs:\t{results.Median(r => r.OutputCount):0.##}");
 	    Console.WriteLine($"Number of changes:\t{results.Average(r => r.ChangeCount):0.##}");
 	    Console.WriteLine($"Total in:\t\t{(decimal)(results.Median(r => (double)r.InputAmount) ?? 0) / 100000000m} BTC");

--- a/Sake/SimulationResult.cs
+++ b/Sake/SimulationResult.cs
@@ -4,6 +4,7 @@ public class SimulationResult
 {
     public int UserCount { get; }
     public int InputCount { get; }
+    public int InputAddedCount { get; }
     public int OutputCount { get; }
     public int ChangeCount { get; }
     public ulong InputAmount { get; }
@@ -25,6 +26,7 @@ public class SimulationResult
     public SimulationResult(
         int userCount,
         int inputCount,
+        int inputAddedCount,
         int outputCount,
         int changeCount,
         ulong inputAmount,
@@ -46,6 +48,7 @@ public class SimulationResult
     {
         UserCount = userCount;
         InputCount = inputCount;
+        InputAddedCount = inputAddedCount;
         OutputCount = outputCount;
         ChangeCount = changeCount;
         InputAmount = inputAmount;


### PR DESCRIPTION
Fixes the inconsistent number of inputs. 
I also changed the display to display the actual number of inputs instead of the theoretical one to catch this kind of issue.